### PR TITLE
Added SDL2_ttf and SDL2_image to the install script

### DIFF
--- a/install_packages_dump.sh
+++ b/install_packages_dump.sh
@@ -33,6 +33,10 @@ packages_list=(boost-devel.x86_64
 	       SDL-static.x86_64
 	       SDL2-static.x86_64
 	       SDL2-devel.x86_64
+	       SDL2_ttf.x86_64
+	       SDL2_ttf-devel.x86_64
+	       SDL2_image.x86_64
+	       SDL2_image-devel.x86_64
 	       libX11-devel.x86_64
 	       libXext-devel.x86_64
 	       ltrace.x86_64


### PR DESCRIPTION
Actually in Tek2, doing the `Arcade` project, we need to develop with the SDL library (we are free to use the version 1 or 2).
But, to use this library we need the `ttf` and `image` plugins to respectively draw text and images.

(Initially requested on GitLab but now opened here, thanks @Xephi).