### PR TITLE
feat(blih): Add environment variable for default user

### DIFF
--- a/blih.py
+++ b/blih.py
@@ -45,7 +45,7 @@ class blih:
         else:
             self.token_calc()
         if user == None:
-            self._user = getpass.getuser()
+            self._user = os.environ.get('BLIH_USER', getpass.getuser())
         else:
             self._user = user
         self._verbose = verbose


### PR DESCRIPTION
This permit to store BLIH default user in `.profile` or `.bashrc` under the environment variable `BLIH_USER` so you don't need the -u each time