### PR TITLE
Add support for Irrlicht graphical library

### DIFF
--- a/install_packages_dump.sh
+++ b/install_packages_dump.sh
@@ -131,7 +131,9 @@ packages_list=(boost-devel.x86_64
 	       php-phar-io-version.noarch
 	       php-theseer-tokenizer.noarch
 	       SFML
-	       SFML-devel)
+	       SFML-devel
+	       irrlicht.x86_64
+	       irrlicht-devel.x86_64)
 
 dnf -y install ${packages_list[@]}
 


### PR DESCRIPTION
Hi,

The project Indie Studio started this monday. We have to create a 3D game inspired from the real Bomberman using the Irrlicht graphical library. When I tried to build the project inside the Epitest's Docker, CMake wasn't able to find the library, that's why I'm here.

If this one is accepted, I can make another for the docker repository (https://github.com/Epitech/epitest-docker).

Have a good day!
Jérémy.