### PR TITLE
 fix(blih): Missing completion on sshkey upload

### DIFF
--- a/bash_completion.d/blih
+++ b/bash_completion.d/blih
@@ -10,6 +10,12 @@ _blih_sshkey() {
 	__blih_arg "_blih_sshkey"
 }
 
+_blih_sshkey_upload() {
+	if [ "$COMP_CWORD" -eq "3" ]; then
+		_filedir
+	fi
+}
+
 _blih_repository() {
 	local commands=(
 		create


### PR DESCRIPTION
`blih sshkey upload` didn't complete with a filename,
This PR fix that