### PR TITLE
/usr/bin/sh might break depending of shell

### DIFF
--- a/install_packages_dump.sh
+++ b/install_packages_dump.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env bash
 
 clear
 echo "INSTALLING PACKAGES FOR EPITECH'S DUMP"


### PR DESCRIPTION
/usr/bin/sh mine is linked to sh and not bash so I get :

```
./install_packages_dump.sh: 5: ./install_packages_dump.sh: [[: not found
Fedora release 32 (Thirty Two)
./install_packages_dump.sh: 10: ./install_packages_dump.sh: [[: not found
Press ENTER to continue...
./install_packages_dump.sh: 15: read: arg count
Warning: failed loading '/etc/yum.repos.d/teams.repo', skipping.
```

using `/usr/bin/env bash` solves the problem