### PR TITLE
feat: Build only CSFML from source, install SFML from dnf

### DIFF
--- a/install_packages_dump.sh
+++ b/install_packages_dump.sh
@@ -121,7 +121,9 @@ packages_list=(boost-devel.x86_64
                x264.x86_64
                lightspark.x86_64
                lightspark-mozilla-plugin.x86_64
-               teams.x86_64)
+               teams.x86_64
+               SFML
+               SFML-devel)
 
 dnf -y install ${packages_list[@]}
 


### PR DESCRIPTION
The SFML is now available in the official Fedora repositories since Fedora 33. Only CSFML needs to be built and installed manually now. 
[The official SMFL package](https://fedora.pkgs.org/33/fedora-x86_64/SFML-2.5.1-4.fc32.x86_64.rpm.html)