### PR TITLE
fix: update dump script for Fedora 36

### DIFF
--- a/install_packages_dump.sh
+++ b/install_packages_dump.sh
@@ -6,9 +6,9 @@ if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root" 1>&2
    exit 1
 fi
-cat /etc/fedora-release | grep "Fedora release 34"
+cat /etc/fedora-release | grep "Fedora release 36"
 if [[ $? -ne 0 ]]; then
-    echo "This script must be run onto a Fedora 34";
+    echo "This script must be run onto a Fedora 36";
     exit 1
 fi
 echo "Press ENTER to continue..."


### PR DESCRIPTION
tl;dr: Updated the `grep` line so that it now works on Fedora 36. :v: 

Documentation has been updated to Fedora 36 (https://github.com/Epitech/dump/commit/26e1ae469bf2182f68df87a2a29557c5509246cc), but not the dump script, which can only be run on Fedora 34. (while September '22 dump was done on 36)