### PR TITLE
fix: add missing curl dependency

### DIFF
--- a/install_packages_dump.sh
+++ b/install_packages_dump.sh
@@ -43,6 +43,7 @@ packages_list=(
     clang
     clang-tools
     cmake
+    curl
     diffutils
     docker-compose
     docker.io


### PR DESCRIPTION
curl is necessary to run some part of the script, adding curl to packages_list.