### PR TITLE
fix: Added missing ncurses-doc package

### DIFF
--- a/install_packages_dump.sh
+++ b/install_packages_dump.sh
@@ -104,6 +104,7 @@ packages_list=(
     mariadb-server
     nasm
     ncurses-base
+    ncurses-doc
     net-tools
     npm
     nodejs


### PR DESCRIPTION
ncurses-doc is necessary for accessing ncurses manual pages, which are assumed to be accessible in some documents (such as the bootstrap for my_top).