### PR TITLE
fix: update to new docker compose version

### DIFF
--- a/install_packages_dump.sh
+++ b/install_packages_dump.sh
@@ -32,6 +32,16 @@ add-apt-repository -y -s universe
 apt update
 apt upgrade -y
 
+apt-get install -y ca-certificates curl
+apt-get install -y -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+
 echo "wireshark-common wireshark-common/install-setuid boolean true" | debconf-set-selections
 
 packages_list=(
@@ -45,8 +55,11 @@ packages_list=(
     cmake
     curl
     diffutils
-    docker-compose
-    docker.io
+    docker-ce
+    docker-ce-cli
+    containerd.io
+    docker-buildx-plugin
+    docker-compose-plugin
     elfutils
     elpa-tuareg
     emacs-nox

--- a/install_packages_dump.sh
+++ b/install_packages_dump.sh
@@ -204,3 +204,4 @@ cd .. && rm -rf vim-epitech
 wget https://raw.githubusercontent.com/Epitech/coding-style-checker/main/coding-style.sh -P /tmp/
 chmod +x /tmp/coding-style.sh
 mv /tmp/coding-style.sh /usr/local/bin/coding-style
+

--- a/install_packages_dump.sh
+++ b/install_packages_dump.sh
@@ -32,16 +32,6 @@ add-apt-repository -y -s universe
 apt update
 apt upgrade -y
 
-apt-get install -y ca-certificates curl
-apt-get install -y -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-chmod a+r /etc/apt/keyrings/docker.asc
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
-  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt-get update
-
 echo "wireshark-common wireshark-common/install-setuid boolean true" | debconf-set-selections
 
 packages_list=(
@@ -55,11 +45,8 @@ packages_list=(
     cmake
     curl
     diffutils
-    docker-ce
-    docker-ce-cli
-    containerd.io
-    docker-buildx-plugin
-    docker-compose-plugin
+    docker.io
+    docker-compose-v2
     elfutils
     elpa-tuareg
     emacs-nox


### PR DESCRIPTION
I update from docker-compose v1 to docker compose v2.
v1 has no support since Jun 2023, and some problems occurs when students try to do popeye project.
Those problems do not appear with v2